### PR TITLE
Stop services before uninstall

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -6,6 +6,10 @@ set -e
 COLOR='\033[92m'
 ENDC='\033[0m'
 
+systemctl stop mytonproviderd
+systemctl stop ton-storage
+systemctl stop ton-storage-provider
+systemctl stop adnl-tunnel
 
 rm -rf /var/storage
 


### PR DESCRIPTION
У одного из провайдеров при переезде сервера, после запуска скрипта удаления, остались запущенными сервисы. Из-за этого mytonprovider.org ходил на старый ip при проверке файлов
Тред: https://t.me/mytonprovider_chat/1328