### PR TITLE
add bag verification daemon and verify_bag, storage_log commands

### DIFF
--- a/modules/ton_storage.py
+++ b/modules/ton_storage.py
@@ -23,6 +23,7 @@ from mypylib import (
 	check_git_update,
 	get_git_author_and_repo,
 	get_timestamp,
+	timeago,
 )
 
 from utils import (
@@ -405,7 +406,8 @@ class Module():
 		if api_data.bags == None:
 			print("no data")
 			return
-		table = [["Bag id", "Progress", "Size", "Files", "Peers", "Download speed", "Upload speed"]]
+		bags_verify_state = self.get_bags_verify_state()
+		table = [["Bag id", "Progress", "Size", "Files", "Peers", "Download speed", "Upload speed", "Last verified"]]
 		for bag in api_data.bags:
 			bag_id = reduct(bag.bag_id)
 			progress = self.get_progress(bag)
@@ -416,7 +418,12 @@ class Module():
 			size_text = f"{size} GB"
 			download_speed_text = f"{download_speed} MB/s"
 			upload_speed_text = f"{upload_speed} MB/s"
-			table += [[bag_id, progress_text, size_text, bag.files_count, bag.peers, download_speed_text, upload_speed_text]]
+			last_verified = bags_verify_state.get(bag.bag_id.upper(), 0)
+			if last_verified == 0:
+				last_verified_text = "never"
+			else:
+				last_verified_text = timeago(last_verified)
+			table += [[bag_id, progress_text, size_text, bag.files_count, bag.peers, download_speed_text, upload_speed_text, last_verified_text]]
 		print_table(table)
 	#end define
 

--- a/mytonprovider.py
+++ b/mytonprovider.py
@@ -47,11 +47,19 @@ def init():
 def init_daemon():
 	#threading.current_thread().name = "daemon"
 	for module in get_modules(local):
+		# Основной daemon
 		method = getattr(module, "daemon", None)
 		if method == None:
 			continue
 		cycle_name = f"{module.name}-daemon"
 		local.start_cycle(module.daemon, name=cycle_name, sec=module.daemon_interval)
+
+		# Дополнительные daemons
+		extra_daemons = getattr(module, "extra_daemons", None)
+		if extra_daemons == None:
+			continue
+		for extra_daemon in extra_daemons:
+			local.start_cycle(extra_daemon.func, name=extra_daemon.name, sec=extra_daemon.interval)
 	thr_sleep()
 #end define
 

--- a/resources/translate.json
+++ b/resources/translate.json
@@ -194,14 +194,24 @@
 		"en": "Display module status",
 		"zh_TW": "顯示模組狀態"
 	},
-	"123": {
-		"ru": "aaa",
-		"en": "bbb",
-		"zh_TW": "ccc"
-	},
 	"ls_status_cmd": {
 		"ru": "Отобразить статус лайт-серверов",
 		"en": "Display lite server status",
 		"zh_TW": "顯示 lite server 狀態"
+	},
+	"verify_bag_cmd": {
+		"ru": "Проверить целостность контейнера",
+		"en": "Verify container integrity",
+		"zh_TW": "驗證容器完整性"
+	},
+	"storage_log_cmd": {
+		"ru": "Установить уровень логирования ton-storage",
+		"en": "Set ton-storage log level",
+		"zh_TW": "設定 ton-storage 日誌等級"
+	},
+	"123": {
+		"ru": "aaa",
+		"en": "bbb",
+		"zh_TW": "ccc"
 	}
 }

--- a/resources/translate.json
+++ b/resources/translate.json
@@ -200,9 +200,9 @@
 		"zh_TW": "顯示 lite server 狀態"
 	},
 	"verify_bag_cmd": {
-		"ru": "Проверить целостность контейнера",
-		"en": "Verify container integrity",
-		"zh_TW": "驗證容器完整性"
+		"ru": "Проверить целостность бэга",
+		"en": "Verify bag integrity",
+		"zh_TW": "驗證 bag 完整性"
 	},
 	"storage_log_cmd": {
 		"ru": "Установить уровень логирования ton-storage",


### PR DESCRIPTION
Adds automatic background verification of bags and two new CLI commands.

- `verify_daemon` — runs every 600s, picks the bag with the oldest verification
  timestamp (cooldown ≥ 30 days), calls `/api/v1/verify`, logs result and
  triggers redownload on failure
- `verify_bag <bag_id>` — manually verify integrity of a specific bag
- `storage_log <verbosity>` — set ton-storage log level (0–13) via `/api/v1/logger`
- `bags_list` now includes "Last verified" column (timeago / "never")
- `init_daemon` extended to support `extra_daemons` per module with individual intervals
- added translations for new commands (ru, en, zh_TW)